### PR TITLE
Add integrity checks for CDN resources

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,12 +6,12 @@
     <link rel="stylesheet" href="libs/css/bootstrap.min.css">
     <link rel="stylesheet" href="libs/css/bootstrap_slate.min.css">
     <link rel="stylesheet" href="css/ark.css">
-    <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-resource.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-route.js"></script>
+    <script src="https://code.jquery.com/jquery-2.1.1.min.js" integrity="sha384-fj9YEHKNa/e0CNquG4NcocjoyMATYo1k2Ff5wGB42C/9AwOlJjDoySPtNJalccfI" crossorigin="anonymous"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.js" integrity="sha384-TJOOLpERTOvNrXRCjF2oyLOS27od4WY6oWZt8XjDmfWy4nNecfU9cvC2yli1DQUn" crossorigin="anonymous"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-resource.js" integrity="sha384-c55syhTCSQrHACyLRdc+4vQZvGrn/A84IhPkRYPzAWVGow6c2X0ZXapzC9zBjko2" crossorigin="anonymous"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-route.js" integrity="sha384-k+Qp/8rZxoiiYGVjOBiZwkEp5yv6clgl2EmwNaE1oUMlfmEYgCWazxf4CyxfZiWG" crossorigin="anonymous"></script>
     <script src="../libs/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/1.3.2/ui-bootstrap-tpls.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/1.3.2/ui-bootstrap-tpls.min.js" integrity="sha384-GkFbgoIeqNVmM/p0DA+XotSxhjwDWI9Fw5bO6Gbp9/tK56xdmYhxj/Sg5XAUTV7V" crossorigin="anonymous"></script>
     <script src="../scripts/ark.js"></script>
 </head>
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -7,9 +7,9 @@
     <link rel="stylesheet" href="libs/css/bootstrap_slate.min.css">
     <link rel="stylesheet" href="css/ark.css">
     <script src="https://code.jquery.com/jquery-2.1.1.min.js" integrity="sha384-fj9YEHKNa/e0CNquG4NcocjoyMATYo1k2Ff5wGB42C/9AwOlJjDoySPtNJalccfI" crossorigin="anonymous"></script>
-	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.js" integrity="sha384-TJOOLpERTOvNrXRCjF2oyLOS27od4WY6oWZt8XjDmfWy4nNecfU9cvC2yli1DQUn" crossorigin="anonymous"></script>
-	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-resource.js" integrity="sha384-c55syhTCSQrHACyLRdc+4vQZvGrn/A84IhPkRYPzAWVGow6c2X0ZXapzC9zBjko2" crossorigin="anonymous"></script>
-	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-route.js" integrity="sha384-k+Qp/8rZxoiiYGVjOBiZwkEp5yv6clgl2EmwNaE1oUMlfmEYgCWazxf4CyxfZiWG" crossorigin="anonymous"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.js" integrity="sha384-TJOOLpERTOvNrXRCjF2oyLOS27od4WY6oWZt8XjDmfWy4nNecfU9cvC2yli1DQUn" crossorigin="anonymous"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-resource.js" integrity="sha384-c55syhTCSQrHACyLRdc+4vQZvGrn/A84IhPkRYPzAWVGow6c2X0ZXapzC9zBjko2" crossorigin="anonymous"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-route.js" integrity="sha384-k+Qp/8rZxoiiYGVjOBiZwkEp5yv6clgl2EmwNaE1oUMlfmEYgCWazxf4CyxfZiWG" crossorigin="anonymous"></script>
     <script src="../libs/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/1.3.2/ui-bootstrap-tpls.min.js" integrity="sha384-GkFbgoIeqNVmM/p0DA+XotSxhjwDWI9Fw5bO6Gbp9/tK56xdmYhxj/Sg5XAUTV7V" crossorigin="anonymous"></script>
     <script src="../scripts/ark.js"></script>


### PR DESCRIPTION
Maybe these resources should be kept as a local copy. In the meantime a integrity check can be used to ensure integrity of external resources.

For browser compatibility of this feature check http://caniuse.com/#feat=subresource-integrity